### PR TITLE
Mode build

### DIFF
--- a/mode_build/Dockerfile
+++ b/mode_build/Dockerfile
@@ -1,0 +1,21 @@
+# build from root of repo by running:
+#   docker build . -f mode_build/Dockerfile
+
+FROM colstrom/concourse-fuselage
+
+RUN apk-install git ca-certificates libressl-dev \
+    && update-ca-certificates \
+    && apk update \
+    && apk del openssl-dev \
+    && rm -vf /var/cache/apk/*
+
+COPY . /build
+WORKDIR /build
+
+RUN cp -f mode_build/concourse-github-status.gemspec ./ \
+    && gem build concourse-github-status.gemspec \
+    && gem install concourse-github-status-0.0.0.gem
+
+WORKDIR /opt/resource
+
+RUN find $(gem environment gemdirs) -type f -path '*/concourse-github-status-*/bin/*' -exec ln -s '{}' \;

--- a/mode_build/README.md
+++ b/mode_build/README.md
@@ -1,0 +1,29 @@
+# Mode's concourse-github-status
+
+The upstream's Dockerfile and gemspec rely on pushing the gem to Rubygems. In order to get around this, we use our own Dockerfile and gemspec.
+
+## Development
+
+### Build the Docker Image
+
+```bash
+# be at the root of the repo
+cd concourse-github-status/
+
+# build the docker image
+docker build . -f mode_build/Dockerfile -t concourse-github-status-resource:${concourse_version}-mode${resource_version}
+```
+
+Example tags:
+ - `concourse-github-status-resource:4.0.0-mode-jasondev`
+ - `concourse-github-status-resource:4.0.0-mode1`
+
+### Push the Docker Image
+
+The docker image is hosted at: `modeanalytics/concourse-github-status-resource` (dockerhub)
+
+```bash
+docker tag concourse-github-status-resource:4.0.0-mode1 modeanalytics/concourse-github-status-resource:4.0.0-mode1
+
+docker push modeanalytics/concourse-github-status-resource:4.0.0-mode1
+```

--- a/mode_build/concourse-github-status.gemspec
+++ b/mode_build/concourse-github-status.gemspec
@@ -1,0 +1,19 @@
+Gem::Specification.new do |gem|
+  gem.name          = 'concourse-github-status'
+  gem.homepage      = 'https://github.com/mode/concourse-github-status'
+  gem.summary       = 'GitHub Status resource for Concourse'
+
+  gem.version       = "0.0.0"
+  gem.licenses      = ['MIT']
+  gem.authors       = ['Chris Olstrom', 'Mode Analytics']
+
+  gem.files         = `git ls-files -z`.split("\x0")
+  gem.executables   = `git ls-files -z -- bin/*`.split("\x0").map { |f| File.basename(f) }
+  gem.test_files    = `git ls-files -z -- {test,spec,features}/*`.split("\x0")
+
+  gem.require_paths = ['lib']
+
+  gem.add_runtime_dependency 'concourse-fuselage', '~> 0.1', '>= 0.1.0'
+  gem.add_runtime_dependency 'git',                '~> 1.3', '>= 1.3.0'
+  gem.add_runtime_dependency 'octokit',            '~> 4.2', '>= 4.2.0'
+end


### PR DESCRIPTION
The default Dockerfile/gemspec relies on actually pushing the gem to Rubygems, which doesn't really help us. Rather than overwrite these files and making it difficult to merge in future changes from upstream, we'll create a separate `mode_build` directory that will remain untouched by the upstream repo.