### PR TITLE
GitHub api wait limit

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,12 +20,14 @@ Add the resource to your pipeline's ~resource_types~ (requires Concourse 0.74.0+
 
 * Source Configuration
 
-|--------------+----------+---------------------------------------------|
-| Name         | Required | Description                                 |
-|--------------+----------+---------------------------------------------|
-| repo         | Yes      | The GitHub repository in ~user/repo~ format |
-| access_token | Yes      | The access token to use with the GitHub API |
-|--------------+----------+---------------------------------------------|
+|-----------------+----------+---------+----------------------------------------------------|
+| Name            | Required | Default | Description                                        |
+|-----------------+----------+---------+----------------------------------------------------|
+| repo            | Yes      |         | The GitHub repository in ~user/repo~ format        |
+| access_token    | Yes      |         | The access token to use with the GitHub API        |
+| api_wait_limit  | No       | 900     | (s) Max time to wait for API ratelimit to reset    |
+| api_wait_buffer | No       | 60      | Min number of available API retries before waiting |
+|-----------------+----------+---------+----------------------------------------------------|
 
 * Behaviour
 

--- a/lib/github-status/check.rb
+++ b/lib/github-status/check.rb
@@ -14,12 +14,16 @@ module GitHubStatus
 
     Contract String => Time
     def date(sha)
-      @date ||= github.commit(repo, sha).commit.author.date
+      if github_ratelimit_ok?
+        @date ||= github.commit(repo, sha).commit.author.date
+      end
     end
 
     Contract None => String
     def commit
-      @commit ||= github.branch(repo, branch).commit.sha
+      if github_ratelimit_ok?
+        @commit ||= github.branch(repo, branch).commit.sha
+      end
     end
 
     Contract None => HashOf[String, String]
@@ -29,9 +33,11 @@ module GitHubStatus
 
     Contract HashOf[String, String] => ArrayOf[HashOf[String, String]]
     def since(version)
-      github
-        .commits_since(repo, date(sha(version)))
-        .map { |commit| { 'context@sha' => "concourseci@#{commit[:sha]}" } }
+      if github_ratelimit_ok?
+        github
+          .commits_since(repo, date(sha(version)))
+          .map { |commit| { 'context@sha' => "concourseci@#{commit[:sha]}" } }
+      end
     end
   end
 end

--- a/lib/github-status/in.rb
+++ b/lib/github-status/in.rb
@@ -17,11 +17,13 @@ module GitHubStatus
 
     Contract None => Maybe[String]
     def state
-      github
-        .statuses(repo, canonical_sha)
-        .select { |status| status.context == context }
-        .map(&:state)
-        .first
+      if github_ratelimit_ok?
+        github
+          .statuses(repo, canonical_sha)
+          .select { |status| status.context == context }
+          .map(&:state)
+          .first
+      end
     end
 
     Contract None => Num

--- a/lib/github-status/out.rb
+++ b/lib/github-status/out.rb
@@ -16,7 +16,7 @@ module GitHubStatus
 
     Contract None => Or[Sawyer::Resource, ArrayOf[Sawyer::Resource]]
     def update!
-      if statuses.empty?
+      if statuses.empty? and github_ratelimit_ok?
         github.create_status repo, canonical_sha, state, options
       else
         statuses.map do |status|
@@ -25,7 +25,9 @@ module GitHubStatus
             target_url: target_url,
             description: status["description"] || ""
           }
-          github.create_status repo, canonical_sha, status["state"], options
+          if github_ratelimit_ok?
+            github.create_status repo, canonical_sha, status["state"], options
+          end
         end
       end
     rescue Octokit::Error => error

--- a/lib/github-status/support/github.rb
+++ b/lib/github-status/support/github.rb
@@ -13,6 +13,25 @@ module GitHubStatus
         @github ||= Octokit::Client.new access_token: access_token
       end
 
+      Contract None => Bool
+      def github_ratelimit_ok?
+        rate_limit_remaining = github.rate_limit.remaining()
+        STDERR.puts "Github requests remaining: #{rate_limit_remaining}"
+        rate_limit_resets_in = github.rate_limit.resets_in()
+        
+        if rate_limit_remaining < 4999
+          if rate_limit_resets_in < api_wait_limit
+            sleep rate_limit_resets_in
+            return true
+          else
+            raise "Github API rate exceeded, time to reset (#{rate_limit_resets_in}s) exceeds wait limit (#{api_wait_limit}s)"
+          end
+        else
+          # continue if we're not reaching ratelimit
+          return true
+        end
+      end
+
       Contract None => String
       def canonical_sha
         @canonical_sha ||= (sha.match(/^.{40}$/) || github.commit(repo, sha).sha).to_s

--- a/lib/github-status/support/github.rb
+++ b/lib/github-status/support/github.rb
@@ -16,15 +16,15 @@ module GitHubStatus
       Contract None => Bool
       def github_ratelimit_ok?
         rate_limit_remaining = github.rate_limit.remaining()
-        STDERR.puts "Github requests remaining: #{rate_limit_remaining}"
         rate_limit_resets_in = github.rate_limit.resets_in()
         
-        if rate_limit_remaining < 4999
+        if rate_limit_remaining < api_wait_buffer
           if rate_limit_resets_in < api_wait_limit
+            STDERR.puts("Github API tries remaining (#{rate_limit_remaining}) is less than buffer (#{api_wait_buffer}). Sleeping for #{rate_limit_resets_in}s..."
             sleep rate_limit_resets_in
             return true
           else
-            raise "Github API rate exceeded, time to reset (#{rate_limit_resets_in}s) exceeds wait limit (#{api_wait_limit}s)"
+            raise "Github API rate exceeded: time to reset (#{rate_limit_resets_in}s) exceeds wait limit (#{api_wait_limit}s)"
           end
         else
           # continue if we're not reaching ratelimit

--- a/lib/github-status/support/source.rb
+++ b/lib/github-status/support/source.rb
@@ -31,6 +31,11 @@ module GitHubStatus
       def api_wait_limit
         @api_wait_limit ||= params.fetch 'api_wait_limit', 900 # 15min
       end
+
+      Contract None => Int
+      def api_wait_buffer
+        @api_wait_buffer ||= params.fetch 'api_wait_buffer', 60
+      end
     end
   end
 end

--- a/lib/github-status/support/source.rb
+++ b/lib/github-status/support/source.rb
@@ -26,6 +26,11 @@ module GitHubStatus
       def branch
         @branch ||= source.fetch('branch') { 'master' }
       end
+
+      Contract None => Int
+      def api_wait_limit
+        @api_wait_limit ||= params.fetch 'api_wait_limit', 900 # 15min
+      end
     end
   end
 end


### PR DESCRIPTION
Due to the number of Github API calls in this resource, you can end up reaching the hourly API limit (5000) fairly quickly if you have many pipelines configured with the same Github user. 

In an attempt to help address this, we're adding two source parameters:
- `api_wait_limit`:  (s) Max time to wait for API ratelimit to reset. The github api resets the limit every hour, so a simple retry after x seconds isn't enough - if we've reached the limit, we need to either wait it out or give up. `api_wait_limit` determines how long we're willing to wait before giving up.
- `api_wait_buffer`: Min number of available API retries before waiting. If there are more available requests than this number, we'll proceed, otherwise we'll attempt to wait it out.