### PR TITLE
Less Github API requests

### DIFF
--- a/lib/github-status/check.rb
+++ b/lib/github-status/check.rb
@@ -2,8 +2,6 @@ require 'concourse-fuselage'
 require_relative 'core'
 require_relative 'support/github'
 
-# version: { "context@sha@date" => "concourseci@12352342345234623423a@2019-06-19 00:00:00"
-
 module GitHubStatus
   class Check < Fuselage::Check
     include Core

--- a/lib/github-status/check.rb
+++ b/lib/github-status/check.rb
@@ -2,6 +2,8 @@ require 'concourse-fuselage'
 require_relative 'core'
 require_relative 'support/github'
 
+# version: { "context@sha@date" => "concourseci@12352342345234623423a@2019-06-19 00:00:00"
+
 module GitHubStatus
   class Check < Fuselage::Check
     include Core
@@ -9,34 +11,33 @@ module GitHubStatus
 
     Contract HashOf[String, String] => String
     def sha(version)
-      @sha ||= version.fetch('context@sha') { commit }.split('@').last
+      @sha ||= version.fetch('context@sha@date') { commit['sha'] }.split('@')[1]
     end
 
-    Contract String => Time
-    def date(sha)
-      if github_ratelimit_ok?
-        @date ||= github.commit(repo, sha).commit.author.date
-      end
+    Contract HashOf[String, String] => String
+    def date(version)
+      @date ||= version.fetch('context@sha@date') { commit['date'] }.split('@').last
     end
 
-    Contract None => String
+    Contract None => HashOf[String, String]
     def commit
       if github_ratelimit_ok?
-        @commit ||= github.branch(repo, branch).commit.sha
+        @branch ||= github.branch(repo, branch)
+        @commit ||= { 'sha' => @branch.commit.sha, 'date' => @branch.commit.commit.author.date.to_s }
       end
     end
 
     Contract None => HashOf[String, String]
     def latest
-      { 'context@sha' => "concourseci@#{commit}" }
+      { 'context@sha@date' => "concourseci@#{commit['sha']}@#{commit['date']}" }
     end
 
     Contract HashOf[String, String] => ArrayOf[HashOf[String, String]]
     def since(version)
       if github_ratelimit_ok?
         github
-          .commits_since(repo, date(sha(version)))
-          .map { |commit| { 'context@sha' => "concourseci@#{commit[:sha]}" } }
+          .commits_since(repo, date(version))
+          .map { |commit| { 'context@sha@date' => "concourseci@#{commit[:sha]}@#{commit.commit.author.date.to_s}" } }
       end
     end
   end

--- a/lib/github-status/in.rb
+++ b/lib/github-status/in.rb
@@ -12,7 +12,7 @@ module GitHubStatus
 
     Contract None => String
     def sha
-      @sha ||= version.fetch('context@sha') { commit }.split('@').last
+      @sha ||= version.fetch('context@sha@date') { commit['sha'] }.split('@')[1]
     end
 
     Contract None => Maybe[String]

--- a/lib/github-status/out.rb
+++ b/lib/github-status/out.rb
@@ -37,7 +37,7 @@ module GitHubStatus
 
     Contract None => HashOf[String, String]
     def version
-      { 'context@sha' => "#{context}@#{canonical_sha}" }
+      { 'context@sha@date' => "#{context}@#{canonical_sha}@#{date}" }
     end
 
     Contract None => String

--- a/lib/github-status/support/git.rb
+++ b/lib/github-status/support/git.rb
@@ -23,6 +23,12 @@ module GitHubStatus
           git.revparse 'HEAD'
         end
       end
+
+      Contract None => String
+      def date
+        commit ||= git.gcommit(sha)
+        @date ||= commit.author.date.to_s
+      end
     end
   end
 end

--- a/lib/github-status/support/github.rb
+++ b/lib/github-status/support/github.rb
@@ -21,7 +21,7 @@ module GitHubStatus
         if rate_limit_remaining < api_wait_buffer
           if rate_limit_resets_in < api_wait_limit
             STDERR.puts("Github API tries remaining (#{rate_limit_remaining}) is less than buffer (#{api_wait_buffer}). Sleeping for #{rate_limit_resets_in}s...")
-            sleep rate_limit_resets_in
+            sleep (rate_limit_resets_in + 5)
             return true
           else
             raise "Github API rate exceeded: time to reset (#{rate_limit_resets_in}s) exceeds wait limit (#{api_wait_limit}s)"


### PR DESCRIPTION
Store the `date` in the version information in order to make less github API calls.

### Num of requests
| | Before | After |
| --- | --- | --- |
| `check` | 3 | 1 |
| `in` |  3 | 1 |
| `out` | 1 | 1 |
